### PR TITLE
Count tables as a line

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ function convertLinesToSlide () {
 }
 
 function getLines () {
-  const lines = $('.lines > .line > .text')
+  const lines = $('.lines > .line > .text, .table-block')
   console.log(`${lines.length} liens found`) // eslint-disable-line
   const result = []
   for (let index = 0; index < lines.length; index++) {


### PR DESCRIPTION
In current presentation mode, `.table-block` is not counted as rows.
ex: https://scrapbox.io/help/%E8%A8%98%E6%B3%95