### PR TITLE
fixed: :not selector not active

### DIFF
--- a/src/index.styl
+++ b/src/index.styl
@@ -17,7 +17,7 @@ html, body, #app-container, #app-container > div, .container-fluid, .row, .page-
 .line
   font-size: 2em
   line-height: 1.2em
-  .text:not(.ac-page-title, .code-block)
+  .text:not(.ac-page-title):not(.code-block)
     margin-bottom: 10px
   img
     zoom: 150%


### PR DESCRIPTION
This PR fix mistake in 863744dcb410fa7a92f32c196d7893c5bdb9816a.
The selector `:not(.ac-page-title, .code-block)` do not work.

![](http://tiqav.com/Hh.jpg)